### PR TITLE
Fix r2modman maps not loading on linux

### DIFF
--- a/Installer.cs
+++ b/Installer.cs
@@ -1,4 +1,4 @@
-﻿using BepInEx.Logging;
+using BepInEx.Logging;
 using Game.Areas;
 using System;
 using System.Collections.Generic;
@@ -121,7 +121,19 @@ namespace MapInstaller
         /// <returns></returns>
         private string GetActiveRModManProfile( )
         {
-            return GetActiveProfile( RMODMAN_PATH );
+
+            if ( Directory.Exists( RMODMAN_PATH ) )
+            {
+                return GetActiveProfile( RMODMAN_PATH );
+            }
+            else
+            {
+                String envVar = Environment.GetEnvironmentVariable( "DOORSTOP_INVOKE_DLL_PATH" );
+                String dllPath = Path.GetDirectoryName( envVar );
+                String profilesPath = Path.GetFullPath( Path.Combine( dllPath, "..", "..", ".." ) );
+
+                return GetActiveProfile( profilesPath );
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
I'm using r2modman on linux and found that maps installed via r2modman aren't being detected.  

The default profiles directory for an r2modman instance in linux is `~/.config/r2modmanPlus-local/CitiesSkylines2/profiles`, though users can change the r2modman data folder.  However CSII is run under proton, where it is isolated in it's own specific wine environment. managed by steam. Using `Environment.SpecialFolder.UserProfile` inside proton returns `C:\users\steamuser` which is actually a directory `~/.local/share/Steam/steamapps/compatdata/949230/pfx/drive_c/users/steamuser`. 

Instead I used the Doorstop environment variable `DOORSTOP_INVOKE_DLL_PATH`, which can be traversed up a few levels to the active r2modman profile.  

caveat: I have only tested this on my machine, on my specific manjaro linux install with r2modman built from source. In principal this should work for any r2modman install.